### PR TITLE
use party a for contract data in getDisputeByHash

### DIFF
--- a/contract_wrapper/KlerosWrapper.js
+++ b/contract_wrapper/KlerosWrapper.js
@@ -291,7 +291,7 @@ class KlerosWrapper extends ContractWrapper {
 
     // get contract data from partyA (should have same docs for both parties)
     const ArbitrableTransaction = new ArbitrableTransactionWrapper(this._Web3Wrapper, this._StoreProvider)
-    let contractData = await ArbitrableTransaction.getDataContract(account, disputeData.contractAddress)
+    let contractData = await ArbitrableTransaction.getDataContract(disputeData.partyA, disputeData.contractAddress)
 
     return {
       contractData,
@@ -343,13 +343,20 @@ class KlerosWrapper extends ContractWrapper {
     account = this._Web3Wrapper.getAccount(0)
   ) => {
     const contractInstance = await this.load(contractAddress)
+
     const juror = await contractInstance.jurors(account)
+    if (!juror) throw new Error(`${account} is not a juror for contract ${contractAddress}`)
+
     // total tokens stored in contract
-    const contractBalance = juror ? this._Web3Wrapper.fromWei(juror[0].toNumber(), 'ether') : 0
+    const contractBalance = this._Web3Wrapper.fromWei(juror[0].toNumber(), 'ether')
     // tokens activated in court session
-    const activatedTokens = juror ? this._Web3Wrapper.fromWei((juror[4].toNumber() - juror[3].toNumber()), 'ether') : 0
+    const currentSession = await contractInstance.session.call()
+    let activatedTokens = 0
+    if (juror[3].toNumber() === currentSession.toNumber()) {
+      activatedTokens = this._Web3Wrapper.fromWei((juror[4].toNumber() - juror[3].toNumber()), 'ether')
+    }
     // tokens locked into disputes
-    const lockedTokens = juror ? this._Web3Wrapper.fromWei(juror[2].toNumber(), 'ether') : 0
+    const lockedTokens = this._Web3Wrapper.fromWei(juror[2].toNumber(), 'ether')
 
     return {
       activatedTokens,
@@ -357,7 +364,7 @@ class KlerosWrapper extends ContractWrapper {
       tokenBalance: contractBalance
     }
   }
-
+  
   /**
    * Activate Pinakion tokens to be eligible to be a juror
    * @param amount number of tokens to activate

--- a/contract_wrapper/KlerosWrapper.js
+++ b/contract_wrapper/KlerosWrapper.js
@@ -352,7 +352,7 @@ class KlerosWrapper extends ContractWrapper {
     // tokens activated in court session
     const currentSession = await contractInstance.session.call()
     let activatedTokens = 0
-    if (juror[3].toNumber() === currentSession.toNumber()) {
+    if (juror[2].toNumber() === currentSession.toNumber()) {
       activatedTokens = this._Web3Wrapper.fromWei((juror[4].toNumber() - juror[3].toNumber()), 'ether')
     }
     // tokens locked into disputes
@@ -364,7 +364,7 @@ class KlerosWrapper extends ContractWrapper {
       tokenBalance: contractBalance
     }
   }
-  
+
   /**
    * Activate Pinakion tokens to be eligible to be a juror
    * @param amount number of tokens to activate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleros-api",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "description": "Kleros API",
   "main": "lib/kleros-api.js",
   "scripts": {


### PR DESCRIPTION
- fix bug where there was no contractData when juror looks up dispute
- fix getPNKBalance so it returns activated tokens in contract only if they were activated for current session