### PR TITLE
fix(getDeadlineForDispute): fix wrong computation and return date object

### DIFF
--- a/src/abstractWrappers/Disputes.js
+++ b/src/abstractWrappers/Disputes.js
@@ -541,6 +541,7 @@ class Disputes extends AbstractWrapper {
       partyB: arbitrableContractData.partyB,
       arbitrableContractStatus: arbitrableContractData.status,
       disputeState: dispute.state,
+      disputeStatus: dispute.status,
       arbitrableContractAddress: arbitrableContractAddress,
       arbitratorAddress: arbitratorAddress,
       fee: dispute.arbitrationFeePerJuror,

--- a/src/abstractWrappers/Disputes.js
+++ b/src/abstractWrappers/Disputes.js
@@ -332,7 +332,7 @@ class Disputes extends AbstractWrapper {
     const arbitratorData = await this._Arbitrator.getData(arbitratorAddress)
 
     // Last period change + current period duration = deadline
-    return new Date(1000 * (arbitratorData.lastPeriodChange + (await this._Arbitrator.getTimeForPeriod(arbitratorAddress, period))))
+    return 1000 * (arbitratorData.lastPeriodChange + (await this._Arbitrator.getTimeForPeriod(arbitratorAddress, period)))
   }
 
   /**

--- a/src/abstractWrappers/Disputes.js
+++ b/src/abstractWrappers/Disputes.js
@@ -319,25 +319,20 @@ class Disputes extends AbstractWrapper {
   }
 
   /**
-  * get the deadline for dispute
-  * @param {string} arbitratorAddress address of arbitrator contract
-  * @param {number} period default to voting period
-  * @return {string} date string in the form dd/mm/yyyy
+  * Gets the deadline for an arbitrator's period, which is also the deadline for all its disputes.
+  * @param {string} arbitratorAddress - The address of the arbitrator contract.
+  * @param {number} [period=PERIODS.VOTE] - The period to get the deadline for.
+  * @return {Date} - A date object.
   */
   getDeadlineForDispute = async (
     arbitratorAddress,
     period = PERIODS.VOTE
   ) => {
+    // Get arbitrator data
     const arbitratorData = await this._Arbitrator.getData(arbitratorAddress)
-    // compute end date
-    const startTime = arbitratorData.lastPeriodChange
-    const length = await this._Arbitrator.getTimeForPeriod(arbitratorAddress, period)
-    // FIXME this is all UTC for now. Timezones are a pain
-    const deadline = new Date(0);
-    deadline.setUTCSeconds(startTime)
-    deadline.setSeconds(deadline.getSeconds() + length);
 
-    return `${deadline.getUTCDate()}/${deadline.getUTCMonth()}/${deadline.getFullYear()}`
+    // Last period change + current period duration = deadline
+    return new Date(1000 * (arbitratorData.lastPeriodChange + (await this._Arbitrator.getTimeForPeriod(arbitratorAddress, period))))
   }
 
   /**

--- a/src/contractWrappers/KlerosWrapper.js
+++ b/src/contractWrappers/KlerosWrapper.js
@@ -381,7 +381,8 @@ class KlerosWrapper extends ContractWrapper {
         rulingChoices: dispute[3].toNumber(),
         initialNumberJurors: dispute[4].toNumber(),
         arbitrationFeePerJuror: dispute[5].toNumber(),
-        state: dispute[6].toNumber()
+        state: dispute[6].toNumber(),
+        status: (await contractInstance.disputeStatus(disputeId)).toNumber()
       }
     } catch (e) {
       throw new Error(e)

--- a/src/test/kleros.test.js
+++ b/src/test/kleros.test.js
@@ -498,7 +498,7 @@ describe('Kleros', () => {
 
     const disputesForJuror = await KlerosInstance.disputes.getDisputesForUser(klerosCourt.address, juror)
     expect(disputesForJuror.length).toEqual(1)
-    expect(disputesForJuror[0].deadline.getTime()).toBe(1000 * (newState.lastPeriodChange + (await klerosPOCInstance.timePerPeriod(newState.period)).toNumber()))
+    expect(disputesForJuror[0].deadline).toBe(1000 * (newState.lastPeriodChange + (await klerosPOCInstance.timePerPeriod(newState.period)).toNumber()))
     expect(disputesForJuror[0].arbitrableContractAddress).toEqual(contractArbitrableTransactionData.address)
     expect(disputesForJuror[0].votes).toEqual([1,2,3])
 

--- a/src/test/kleros.test.js
+++ b/src/test/kleros.test.js
@@ -498,6 +498,7 @@ describe('Kleros', () => {
 
     const disputesForJuror = await KlerosInstance.disputes.getDisputesForUser(klerosCourt.address, juror)
     expect(disputesForJuror.length).toEqual(1)
+    expect(disputesForJuror[0].deadline.getTime()).toBe(1000 * (newState.lastPeriodChange + (await klerosPOCInstance.timePerPeriod(newState.period)).toNumber()))
     expect(disputesForJuror[0].arbitrableContractAddress).toEqual(contractArbitrableTransactionData.address)
     expect(disputesForJuror[0].votes).toEqual([1,2,3])
 


### PR DESCRIPTION
The way the deadline was being calculated was wrong.  The `/(set|get)(UTC)?Seconds/` functions operate on the seconds left over, i.e. date.getTime() % (1000 * 60).

I also made it return a date object so we don't have to parse it in the dapp.

I also added disputeStatus to the returned disputes. We need this for the UI.