### PR TITLE
Update dispute properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.0.63"></a>
+
+## [0.0.63](https://github.com/kleros/kleros-api/compare/v0.0.62...v0.0.63) (2018-03-05)
+
+### Features
+
+* **disputes:** all functions working with new structure ([39e9b2c](https://github.com/kleros/kleros-api/commit/39e9b2c))
+* **disputes:** DRY out fetch open disputes for session and add deadline event handler ([c66548a](https://github.com/kleros/kleros-api/commit/c66548a))
+* **disputes:** skeleton for new dispute data ([2382e39](https://github.com/kleros/kleros-api/commit/2382e39))
+
 <a name="0.0.62"></a>
 
 ## 0.0.62 (2018-02-28)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kleros-api",
-  "version": "0.0.62",
+  "version": "0.0.63",
   "description":
     "A Javascript library that makes it easy to build relayers and other DApps that use the Kleros protocol.",
   "keywords": ["Blockchain", "Ethereum", "Kleros"],

--- a/src/abstractWrappers/Notifications.js
+++ b/src/abstractWrappers/Notifications.js
@@ -92,12 +92,15 @@ class Notifications extends AbstractWrapper {
           )
         }
       } else if (currentPeriod === arbitratorConstants.PERIOD.VOTE) {
-        userProfile.disputes.forEach(dispute => {
-          if (
-            dispute.isJuror &&
-            dispute.votes.length > 0 &&
-            !dispute.hasRuled
-          ) {
+        for (let dispute of userProfile.disputes) {
+          const draws = dispute.appealDraws[dispute.appealDraws.length - 1]
+          const canVote = await this._Arbitrator.canRuleDispute(
+            dispute.arbitratorAddress,
+            dispute.disputeId,
+            draws,
+            account
+          )
+          if (canVote) {
             notifications.push(
               this._createNotification(
                 notificationConstants.TYPE.CAN_VOTE,
@@ -109,7 +112,7 @@ class Notifications extends AbstractWrapper {
               )
             )
           }
-        })
+        }
       }
     } else {
       /* Counterparty notifications:

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,0 +1,3 @@
+export const TYPE = {
+  DISPUTE_OUT_OF_RANGE: 'Dispute out of range'
+}

--- a/src/constants/eth.js
+++ b/src/constants/eth.js
@@ -1,5 +1,6 @@
 export const LOCALHOST_ETH_PROVIDER = 'http://localhost:8545'
-export const LOCALHOST_STORE_PROVIDER = 'https://kleros.in'
+// export const LOCALHOST_STORE_PROVIDER = 'https://kleros.in'
+export const LOCALHOST_STORE_PROVIDER = 'http://localhost:3001'
 
 export const NULL_ADDRESS = '0x'
 

--- a/src/constants/eth.js
+++ b/src/constants/eth.js
@@ -1,6 +1,6 @@
 export const LOCALHOST_ETH_PROVIDER = 'http://localhost:8545'
-// export const LOCALHOST_STORE_PROVIDER = 'https://kleros.in'
-export const LOCALHOST_STORE_PROVIDER = 'http://localhost:3001'
+export const LOCALHOST_STORE_PROVIDER = 'https://kleros.in'
+// export const LOCALHOST_STORE_PROVIDER = 'http://localhost:3001'
 
 export const NULL_ADDRESS = '0x'
 

--- a/src/contractWrappers/KlerosWrapper.js
+++ b/src/contractWrappers/KlerosWrapper.js
@@ -438,9 +438,9 @@ class KlerosWrapper extends ContractWrapper {
     contractAddress,
     jurorAddress = this._Web3Wrapper.getAccount(0)
   ) => {
-    this.contractInstance = await this.load(contractAddress)
+    const contractInstance = await this.load(contractAddress)
 
-    const isDrawn = await this.contractInstance.isDrawn(
+    const isDrawn = await contractInstance.isDrawn(
       disputeId,
       jurorAddress,
       draw
@@ -450,23 +450,28 @@ class KlerosWrapper extends ContractWrapper {
   }
 
   /**
-   * Can juror currently rule in dispute
-   *
+   * Can juror currently rule in dispute.
+   * @param {string} arbitratorAddress - address of arbitrator contract.
+   * @param {number} disputeId - index of dispute.
+   * @param {int[]} draws - voting positions for dispute.
+   * @param {string} account - address of user.
+   * @returns {bool} - Boolean indicating if juror can rule or not.
    */
   canRuleDispute = async (arbitratorAddress, disputeId, draws, account) => {
-    this.contractInstance = await this.load(contractAddress)
+    const contractInstance = await this.load(arbitratorAddress)
 
-    return this.contractInstance.validDraws(account, disputeId, draws)
+    return contractInstance.validDraws(account, disputeId, draws)
   }
 
   /**
    * Get number of jurors for a dispute.
    * @param {string} contractAddress - Address of KlerosPOC contract.
    * @param {number} disputeId - Index of dispute.
+   * @param {number} appeal - Index of appeal.
    * @returns {number} - Int indicating the ruling of the dispute.
    */
   currentRulingForDispute = async (contractAddress, disputeId, appeal) => {
-    this.contractInstance = await this.load(contractAddress)
+    const contractInstance = await this.load(contractAddress)
 
     const ruling = await contractInstance.getWinningChoice(disputeId, appeal)
 
@@ -479,7 +484,7 @@ class KlerosWrapper extends ContractWrapper {
    * @returns {number} - Int indicating the period.
    */
   getPeriod = async contractAddress => {
-    this.contractInstance = await this.load(contractAddress)
+    const contractInstance = await this.load(contractAddress)
 
     const currentPeriod = await contractInstance.period()
 
@@ -492,7 +497,7 @@ class KlerosWrapper extends ContractWrapper {
    * @returns {number} - Int indicating the session.
    */
   getSession = async contractAddress => {
-    this.contractInstance = await this.load(contractAddress)
+    const contractInstance = await this.load(contractAddress)
 
     const currentSession = await contractInstance.session()
 

--- a/src/contractWrappers/KlerosWrapper.js
+++ b/src/contractWrappers/KlerosWrapper.js
@@ -438,9 +438,9 @@ class KlerosWrapper extends ContractWrapper {
     contractAddress,
     jurorAddress = this._Web3Wrapper.getAccount(0)
   ) => {
-    const contractInstance = await this.load(contractAddress)
+    this.contractInstance = await this.load(contractAddress)
 
-    const isDrawn = await contractInstance.isDrawn(
+    const isDrawn = await this.contractInstance.isDrawn(
       disputeId,
       jurorAddress,
       draw
@@ -450,17 +450,27 @@ class KlerosWrapper extends ContractWrapper {
   }
 
   /**
+   * Can juror currently rule in dispute
+   *
+   */
+  canRuleDispute = async (arbitratorAddress, disputeId, draws, account) => {
+    this.contractInstance = await this.load(contractAddress)
+
+    return this.contractInstance.validDraws(account, disputeId, draws)
+  }
+
+  /**
    * Get number of jurors for a dispute.
    * @param {string} contractAddress - Address of KlerosPOC contract.
    * @param {number} disputeId - Index of dispute.
    * @returns {number} - Int indicating the ruling of the dispute.
    */
-  currentRulingForDispute = async (contractAddress, disputeId) => {
-    const contractInstance = await this.load(contractAddress)
+  currentRulingForDispute = async (contractAddress, disputeId, appeal) => {
+    this.contractInstance = await this.load(contractAddress)
 
-    const currentRuling = await contractInstance.currentRuling(disputeId)
+    const ruling = await contractInstance.getWinningChoice(disputeId, appeal)
 
-    return currentRuling.toNumber()
+    return ruling.toNumber()
   }
 
   /**
@@ -469,7 +479,7 @@ class KlerosWrapper extends ContractWrapper {
    * @returns {number} - Int indicating the period.
    */
   getPeriod = async contractAddress => {
-    const contractInstance = await this.load(contractAddress)
+    this.contractInstance = await this.load(contractAddress)
 
     const currentPeriod = await contractInstance.period()
 
@@ -482,7 +492,7 @@ class KlerosWrapper extends ContractWrapper {
    * @returns {number} - Int indicating the session.
    */
   getSession = async contractAddress => {
-    const contractInstance = await this.load(contractAddress)
+    this.contractInstance = await this.load(contractAddress)
 
     const currentSession = await contractInstance.session()
 

--- a/src/kleros.js
+++ b/src/kleros.js
@@ -88,6 +88,7 @@ class Kleros {
       account,
       callback
     )
+    await this.disputes.addDisputeDeadlineHandler(arbitratorAddress, account)
     await this.disputes.addDisputeRulingHandler(
       arbitratorAddress,
       account,

--- a/src/utils/StoreProviderWrapper.js
+++ b/src/utils/StoreProviderWrapper.js
@@ -182,11 +182,9 @@ class StoreProviderWrapper {
   // FIXME very complicated to update
   updateDisputeProfile = async (
     account,
-    votes,
+    appealDraws,
     arbitratorAddress,
     disputeId,
-    isJuror,
-    hasRuled,
     netPNK
   ) => {
     const httpResponse = await this._makeRequest(
@@ -195,11 +193,9 @@ class StoreProviderWrapper {
         this._storeUri
       }/${account}/arbitrators/${arbitratorAddress}/disputes/${disputeId}`,
       JSON.stringify({
-        votes,
+        appealDraws,
         arbitratorAddress,
         disputeId,
-        isJuror,
-        hasRuled,
         netPNK
       })
     )
@@ -211,19 +207,16 @@ class StoreProviderWrapper {
   updateDispute = async (
     disputeId,
     arbitratorAddress,
-    hash,
     arbitrableContractAddress,
     partyA,
     partyB,
     title,
-    deadline,
     status,
-    fee,
     information,
     justification,
     resolutionOptions,
-    createdAt,
-    ruledAt
+    appealCreatedAt,
+    appealRuledAt
   ) => {
     const httpResponse = await this._makeRequest(
       'POST',
@@ -233,19 +226,16 @@ class StoreProviderWrapper {
       JSON.stringify({
         disputeId,
         arbitratorAddress,
-        hash,
-        contractAddress: arbitrableContractAddress,
+        arbitrableContractAddress,
         partyA,
         partyB,
         title,
-        deadline,
         status,
-        fee,
         information,
         justification,
         resolutionOptions,
-        createdAt,
-        ruledAt
+        appealCreatedAt,
+        appealRuledAt
       })
     )
     return httpResponse

--- a/src/utils/StoreProviderWrapper.js
+++ b/src/utils/StoreProviderWrapper.js
@@ -216,7 +216,8 @@ class StoreProviderWrapper {
     justification,
     resolutionOptions,
     appealCreatedAt,
-    appealRuledAt
+    appealRuledAt,
+    appealDeadlines
   ) => {
     const httpResponse = await this._makeRequest(
       'POST',
@@ -235,7 +236,8 @@ class StoreProviderWrapper {
         justification,
         resolutionOptions,
         appealCreatedAt,
-        appealRuledAt
+        appealRuledAt,
+        appealDeadlines
       })
     )
     return httpResponse

--- a/tests/abstractWrappers/Disputes.test.js
+++ b/tests/abstractWrappers/Disputes.test.js
@@ -76,8 +76,8 @@ describe('Disputes', () => {
 
       disputesInstance._Arbitrator.getDispute = mockGetDispute
 
-      // mock getVotesForJuror to say juror is selected
-      disputesInstance.getVotesForJuror = jest
+      // mock getDrawsForJuror to say juror is selected
+      disputesInstance.getDrawsForJuror = jest
         .fn()
         .mockReturnValue(_asyncMockResponse([1]))
 
@@ -124,8 +124,8 @@ describe('Disputes', () => {
 
       disputesInstance._Arbitrator.getDispute = mockGetDispute
 
-      // mock getVotesForJuror to say juror has no votes
-      disputesInstance.getVotesForJuror = jest
+      // mock getDrawsForJuror to say juror has no votes
+      disputesInstance.getDrawsForJuror = jest
         .fn()
         .mockReturnValue(_asyncMockResponse([]))
 
@@ -172,8 +172,8 @@ describe('Disputes', () => {
 
       disputesInstance._Arbitrator.getDispute = mockGetDispute
 
-      // mock getVotesForJuror to say juror is selected
-      disputesInstance.getVotesForJuror = jest
+      // mock getDrawsForJuror to say juror is selected
+      disputesInstance.getDrawsForJuror = jest
         .fn()
         .mockReturnValue(_asyncMockResponse([1]))
 
@@ -220,8 +220,8 @@ describe('Disputes', () => {
 
       disputesInstance._Arbitrator.getDispute = mockGetDispute
 
-      // mock getVotesForJuror to say juror has votes so we will know if it is getting further than we expect
-      disputesInstance.getVotesForJuror = jest
+      // mock getDrawsForJuror to say juror has votes so we will know if it is getting further than we expect
+      disputesInstance.getDrawsForJuror = jest
         .fn()
         .mockReturnValue(_asyncMockResponse([1]))
 

--- a/tests/kleros.test.js
+++ b/tests/kleros.test.js
@@ -637,7 +637,7 @@ describe('Kleros', () => {
         disputesForJuror1.length > 0
           ? disputesForJuror1[0]
           : disputesForJuror2[0]
-      expect(disputeForJuror.deadline).toBe(
+      expect(disputeForJuror.appealRulings[0].deadline).toBe(
         1000 *
           (newState.lastPeriodChange +
             (await klerosPOCInstance.timePerPeriod(newState.period)).toNumber())
@@ -800,7 +800,7 @@ describe('Kleros', () => {
       const allNotifications = await KlerosInstance.notifications.getNotifications(
         partyA
       )
-      // expect(allNotifications.length).toBe(notifications.length) // TODO Broken
+      expect(allNotifications.length).toBe(notifications.length) // TODO Broken
 
       let notificationTypesExpected = [
         notificationConstants.TYPE.DISPUTE_CREATED,
@@ -868,11 +868,10 @@ describe('Kleros', () => {
       const disputeData = await KlerosInstance.disputes.getDataForDispute(
         klerosCourt.address,
         0,
-        partyA
+        juror1
       )
-
-      expect(disputeData.createdAt).toBeTruthy()
-      expect(disputeData.ruledAt).toBeTruthy()
+      expect(disputeData.appealCreatedAt.length).toEqual(1)
+      expect(disputeData.appealRuledAt.length).toEqual(1)
     },
     80000
   )

--- a/tests/kleros.test.js
+++ b/tests/kleros.test.js
@@ -621,6 +621,10 @@ describe('Kleros', () => {
           drawB.push(i)
         }
       }
+
+      // FIXME bandaid until PR #92 is merged
+      await delaySecond(2)
+
       expect(drawA.length + drawB.length).toEqual(3)
       const disputesForJuror1 = await KlerosInstance.disputes.getDisputesForUser(
         klerosCourt.address,


### PR DESCRIPTION
Goes with https://github.com/kleros/kleros-store/pull/34

- Removes unused data points and restructures shape of `disputeData` so that data on individual appeals can be returned.
- DRY out open dispute fetching

Example of disputeData:
```
{ 
      arbitrableContractAddress: '0xdd30bf263e5fe1da07ddb5326fefdf17972663ce',
      arbitrableContractStatus: 4,
      arbitratorAddress: '0x405b80b0342c76fcb4ee295b74e232023019756c',
      partyA: '0xccc6366dc9da1362da4844372ac2ad849cd7f3f2',
      partyB: '0xcb045d43381cceebd94a1245ff4bc81108033488',
      disputeId: 0,
      firstSession: 1,
      lastSession: 1,
      numberOfAppeals: 0,
      disputeState: 3,
      disputeStatus: 2,
      appealRulings: 
       [ { ruling: 1,
           voteCounter: [[2, 1]],
           ruledAt: 1520241087000,
           deadline: 1520241090000 } ],
      appealJuror: [ { fee: 0.1, draws: [1, 2], canRule: false } ],
      description: 'test description',
      email: 'test@kleros.io',
      evidence: 
       [ { name: 'test name',
           description: 'test description',
           url: 'http://test.com',
           submittedAt: 1520241074602,
           _id: '5a9d09b2956bef0fbd75539e',
           submitter: '0xccc6366dc9da1362da4844372ac2ad849cd7f3f2' } ],
      netPNK: 20000000000000000,
      appealCreatedAt: [ 1520241071000 ],
      appealRuledAt: [ 1520241087000 ],
      appealDeadlines: [ 1520241090000 ]
}
```