### PR TITLE
Feat/require params

### DIFF
--- a/src/abstractWrappers/AbstractWrapper.js
+++ b/src/abstractWrappers/AbstractWrapper.js
@@ -1,6 +1,7 @@
 import _ from 'lodash'
 
 import * as errorConstants from '../constants/error'
+import isRequired from '../utils/isRequired'
 
 class AbstractWrapper {
   /**
@@ -10,7 +11,10 @@ class AbstractWrapper {
    * @param {object} contractWrapperInstance - Contract Wrapper object to extend
    * @param {object} storeProviderWrapperInstance - StoreProvider wrapper object.
    */
-  constructor(contractWrapperInstance, storeProviderWrapperInstance) {
+  constructor(
+    contractWrapperInstance = isRequired('contractWrapperInstance'),
+    storeProviderWrapperInstance = isRequired('storeProviderWrapperInstance')
+  ) {
     this._StoreProvider = storeProviderWrapperInstance
     // Should still use this._contractWrapper... over this... even after calls are delegating in case any calls were overwritten by child
     this._contractWrapper = contractWrapperInstance

--- a/src/abstractWrappers/index.js
+++ b/src/abstractWrappers/index.js
@@ -1,0 +1,4 @@
+import Arbitrator from './arbitrator'
+import ArbitrableContracts from './arbitrableContracts'
+
+export { Arbitrator, ArbitrableContracts }

--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -1,3 +1,6 @@
+// Kleros
+export const MISSING_PARAMETERS = name => `Missing required parameter: ${name}`
+
 // StoreProviderWrapper
 export const PROFILE_NOT_FOUND = user => `No profile found for user: ${user}.`
 export const NOTIFICATION_NOT_FOUND = txHash =>

--- a/src/contractWrappers/PNK/PinakionPOC/index.js
+++ b/src/contractWrappers/PNK/PinakionPOC/index.js
@@ -4,6 +4,7 @@ import _ from 'lodash'
 import * as ethConstants from '../../../constants/eth'
 import * as errorConstants from '../../../constants/error'
 import ContractWrapper from '../../ContractWrapper'
+import deployContractAsync from '../../../utils/deployContractAsync'
 
 /**
  * Kleros API
@@ -24,17 +25,17 @@ class PinakionWrapper extends ContractWrapper {
 
   /**
    * Kleros deploy.
-   * @param {string} account - (default: accounts[0]).
+   * @param {string} account - account of user
+   * @param {object} web3Provider - web3 provider object
    * @returns {object} - 'truffle-contract' Object | err The contract object or error deploy.
    */
-  deploy = async (account = this._Web3Wrapper.getAccount(0)) => {
-    const contractDeployed = await this._deployAsync(
+  static deploy = async (account, web3Provider) => {
+    const contractDeployed = await deployContractAsync(
       account,
-      ethConstants.TRANSACTION.value,
-      PinakionPOC
+      ethConstants.TRANSACTION.VALUE,
+      PinakionPOC,
+      web3Provider
     )
-
-    this.address = contractDeployed.address
 
     return contractDeployed
   }

--- a/src/contractWrappers/RNG/BlockHashRNG/index.js
+++ b/src/contractWrappers/RNG/BlockHashRNG/index.js
@@ -3,6 +3,7 @@ import _ from 'lodash'
 
 import * as ethConstants from '../../../constants/eth'
 import ContractWrapper from '../../ContractWrapper'
+import deployContractAsync from '../../../utils/deployContractAsync'
 
 /**
  * Kleros API
@@ -23,18 +24,17 @@ class BlockHashRNGWrapper extends ContractWrapper {
 
   /**
    * Kleros deploy.
-   * @param {string} account - (default: accounts[0])
-   * @param {number} value - (default: 10000)
+   * @param {string} account - users account
+   * @param {object} web3Provider - web3 provider object
    * @returns {object} - truffle-contract Object | err The contract object or error deploy
    */
-  deploy = async (account = this._Web3Wrapper.getAccount(0)) => {
-    const contractDeployed = await this._deployAsync(
+  static deploy = async (account, web3Provider) => {
+    const contractDeployed = await deployContractAsync(
       account,
       ethConstants.TRANSACTION.VALUE,
-      RNG
+      RNG,
+      web3Provider
     )
-
-    this.address = contractDeployed.address
 
     return contractDeployed
   }

--- a/src/contractWrappers/arbitrableContracts/ArbitrableTransaction/index.js
+++ b/src/contractWrappers/arbitrableContracts/ArbitrableTransaction/index.js
@@ -5,6 +5,7 @@ import * as ethConstants from '../../../constants/eth'
 import * as contractConstants from '../../../constants/contract'
 import * as errorConstants from '../../../constants/error'
 import ContractWrapper from '../../ContractWrapper'
+import deployContractAsync from '../../../utils/deployContractAsync'
 
 /**
  * ArbitrableTransaction API
@@ -32,30 +33,30 @@ class ArbitrableTransactionWrapper extends ContractWrapper {
    * @param {number} timeout Time after which a party automatically loose a dispute. (default 3600)
    * @param {string} partyB The recipient of the transaction. (default account[1])
    * @param {bytes} arbitratorExtraData Extra data for the arbitrator. (default empty string)
+   * @param {object} web3Provider web3 provider object
    * @returns {object} truffle-contract Object | err The deployed contract or an error
    */
-  deploy = async (
+  static deploy = async (
     account,
     value = ethConstants.TRANSACTION.VALUE,
     hashContract,
     arbitratorAddress,
     timeout,
     partyB,
-    arbitratorExtraData = ''
+    arbitratorExtraData = '',
+    web3Provider
   ) => {
-    const contractDeployed = await this._deployAsync(
+    const contractDeployed = await deployContractAsync(
       account,
       value,
       arbitrableTransaction,
+      web3Provider,
       arbitratorAddress,
       hashContract,
       timeout,
       partyB,
       arbitratorExtraData
     )
-
-    this.address = contractDeployed.address
-    this.contractInstance = contractDeployed
 
     return contractDeployed
   }

--- a/src/contractWrappers/arbitrableContracts/index.js
+++ b/src/contractWrappers/arbitrableContracts/index.js
@@ -1,3 +1,3 @@
-import _ArbitrableTransaction from './ArbitrableTransaction'
+import ArbitrableTransaction from './ArbitrableTransaction'
 
-export const ArbitrableTransaction = _ArbitrableTransaction
+export { ArbitrableTransaction }

--- a/src/contractWrappers/arbitrator/index.js
+++ b/src/contractWrappers/arbitrator/index.js
@@ -1,3 +1,3 @@
-import _KlerosPOC from './KlerosPOC'
+import KlerosPOC from './KlerosPOC'
 
-export const KlerosPOC = _KlerosPOC
+export { KlerosPOC }

--- a/src/contractWrappers/index.js
+++ b/src/contractWrappers/index.js
@@ -1,9 +1,6 @@
-import * as _arbitrator from './arbitrator'
-import * as _arbitrableContracts from './arbitrableContracts'
-import * as _PNK from './PNK'
-import * as _RNG from './RNG'
+import * as arbitrator from './arbitrator'
+import * as arbitrableContracts from './arbitrableContracts'
+import * as PNK from './PNK'
+import * as RNG from './RNG'
 
-export const arbitrator = _arbitrator
-export const arbitrableContracts = _arbitrableContracts
-export const PNK = _PNK
-export const RNG = _RNG
+export { arbitrator, arbitrableContracts, PNK, RNG }

--- a/src/resourceWrappers/EventListeners/index.js
+++ b/src/resourceWrappers/EventListeners/index.js
@@ -9,7 +9,7 @@ class EventListeners extends ResourceWrapper {
    * @param {object} storeProviderWrapper - StoreProvider instance.
    */
   constructor(arbitratorWrapper, arbitrableWrapper, storeProviderWrapper) {
-    super(arbitratorWrapper, arbitrableWrapper, storeProviderWrapper)
+    super(arbitratorWrapper, arbitrableWrapper, undefined, storeProviderWrapper)
     this._arbitratorEventMap = {} // key: event name, value: [event handlers, ...]
     this._arbitrableEventMap = {} // key: event name, value: [event handlers, ...]
     this._arbitratorEventsWatcher = null

--- a/src/resourceWrappers/ResourceWrapper.js
+++ b/src/resourceWrappers/ResourceWrapper.js
@@ -94,7 +94,7 @@ class ResourceWrapper {
    */
   _loadArbitratorInstance = () => {
     this._checkArbitratorWrappersSet()
-    return this._Arbitrator.getContractInstance()
+    return this._Arbitrator.loadContract()
   }
 
   /**
@@ -105,57 +105,6 @@ class ResourceWrapper {
   _loadArbitrableInstance = async arbitrableAddress => {
     this._checkArbitrableWrappersSet()
     return this._ArbitrableContract.load(arbitrableAddress)
-  }
-
-  /**
-   * Creates a new notification object in the store.
-   * @param {string} account - The account.
-   * @param {string} txHash - The txHash.
-   * @param {number} logIndex - The logIndex.
-   * @param {number} notificationType - The notificationType.
-   * @param {string} message - The message.
-   * @param {object} data - The data.
-   * @param {bool} read - Wether the notification has been read or not.
-   * @returns {function} - The notification object.
-   */
-  _newNotification = async (
-    account,
-    txHash,
-    logIndex,
-    notificationType,
-    message = '',
-    data = {},
-    read = false
-  ) => {
-    if (this._hasStoreProvider()) {
-      const response = await this._StoreProvider.newNotification(
-        account,
-        txHash,
-        logIndex,
-        notificationType,
-        message,
-        data,
-        read
-      )
-
-      if (response.status === 201) {
-        const notification = response.body.notifications.filter(
-          notification =>
-            notification.txHash === txHash && notification.logIndex === logIndex
-        )
-        return notification[0]
-      }
-    } else {
-      // If we have no store provider simply return object of params.
-      return {
-        txHash,
-        logIndex,
-        notificationType,
-        message,
-        data,
-        read
-      }
-    }
   }
 
   /**

--- a/src/resourceWrappers/index.js
+++ b/src/resourceWrappers/index.js
@@ -1,7 +1,5 @@
-import _Disputes from './Disputes'
-import _EventListeners from './EventListeners'
-import _Notifications from './Notifications'
+import Disputes from './Disputes'
+import EventListeners from './EventListeners'
+import Notifications from './Notifications'
 
-export const Disputes = _Disputes
-export const EventListeners = _EventListeners
-export const Notifications = _Notifications
+export { Disputes, EventListeners, Notifications }

--- a/src/utils/deployContractAsync.js
+++ b/src/utils/deployContractAsync.js
@@ -1,0 +1,44 @@
+import contract from 'truffle-contract'
+
+import * as ethConstants from '../constants/eth'
+import { UNABLE_TO_DEPLOY_CONTRACT } from '../constants/error'
+
+import isRequired from './isRequired'
+
+/**
+ * Deploy contract.
+ * @param {string} account - The account to deploy it under.
+ * @param {number} value - The value to send.
+ * @param {object} artifact - JSON artifact of the contract.
+ * @param {object} web3Provider - Web3 Provider object (NOTE NOT Kleros Web3Wrapper)
+ * @param {...any} args - Extra arguments.
+ * @returns {object} - truffle-contract Object | err The contract object or an error
+ */
+const deployContractAsync = async (
+  account = isRequired('account'),
+  value = isRequired('value'),
+  artifact = isRequired('artifact'),
+  web3Provider = isRequired('web3Provider'),
+  ...args
+) => {
+  try {
+    const MyContract = contract({
+      abi: artifact.abi,
+      unlinked_binary: artifact.bytecode
+        ? artifact.bytecode
+        : artifact.unlinked_binary
+    })
+    MyContract.setProvider(web3Provider)
+
+    return MyContract.new(...args, {
+      from: account,
+      value: value,
+      gas: ethConstants.TRANSACTION.GAS
+    })
+  } catch (err) {
+    console.error(err)
+    throw new Error(UNABLE_TO_DEPLOY_CONTRACT)
+  }
+}
+
+export default deployContractAsync

--- a/src/utils/isRequired.js
+++ b/src/utils/isRequired.js
@@ -1,0 +1,7 @@
+import { MISSING_PARAMETERS } from '../constants/error'
+
+const isRequired = name => {
+  throw new Error(MISSING_PARAMETERS(name))
+}
+
+export default isRequired

--- a/tests/unit/abstractWrappers/ArbitrableContract.test.js
+++ b/tests/unit/abstractWrappers/ArbitrableContract.test.js
@@ -6,9 +6,10 @@ describe('ArbitrableContract', async () => {
   let arbitrableContractInstance
 
   beforeEach(async () => {
-    const _arbitrableTransaction = new ArbitrableTransaction()
+    const _arbitrableTransaction = new ArbitrableTransaction({})
     arbitrableContractInstance = new ArbitrableContractApi(
-      _arbitrableTransaction
+      _arbitrableTransaction,
+      {}
     )
   })
 

--- a/tests/unit/abstractWrappers/Arbitrator.test.js
+++ b/tests/unit/abstractWrappers/Arbitrator.test.js
@@ -1,5 +1,4 @@
 import ArbitratorApi from '../../../src/abstractWrappers/arbitrator'
-import KlerosPOC from '../../../src/contractWrappers/arbitrator/KlerosPOC'
 import _asyncMockResponse from '../../helpers/asyncMockResponse'
 
 describe('Arbitrator', () => {
@@ -8,8 +7,7 @@ describe('Arbitrator', () => {
   let arbitratorInstance
 
   beforeEach(async () => {
-    const _klerosPOC = new KlerosPOC()
-    arbitratorInstance = new ArbitratorApi(_klerosPOC)
+    arbitratorInstance = new ArbitratorApi({}, {})
   })
 
   describe('getDisputesForUser', async () => {

--- a/tests/unit/resourceWrappers/Disputes.test.js
+++ b/tests/unit/resourceWrappers/Disputes.test.js
@@ -12,7 +12,9 @@ describe('Disputes', () => {
   beforeEach(async () => {
     disputesInstance = new DisputesApi(
       mockArbitratorWrapper,
-      mockArbitrableContractWrapper
+      mockArbitrableContractWrapper,
+      {},
+      {}
     )
 
     mockArbitratorWrapper = {


### PR DESCRIPTION
- Make all contracts `deploy` methods static
- Use a promise to track loading/failure of StatefulContract
- StatefulContract DOES NOT load in the constructor. This is because it makes it extremely hard to handle an error if it should fail.
- Add function `loadContract` in `StatefulContractWrapper` that loads the contract, or returns the contract instance or loading promise if already loading/loaded. This is called at the beginning of every `KlerosPOC` method.
- Make some of the wrappers required in constructors. NOTE: They are not required at the base level of resource wrappers. This is because Notifications and Event Listeners can still function without many of these wrappers. Therefore for resource wrappers they are required at a higher level.

NOTE: Tests no longer use base level `Kleros` object, as there is no StoreProvider, which is now required