### PR TITLE
feat(bonding-curve): add support for the bonding curve contract

### DIFF
--- a/src/constants/error.js
+++ b/src/constants/error.js
@@ -91,3 +91,8 @@ export const ERROR_FETCHING_EVENTS = error => `Unable to fetch events: ${error}`
 export const UNABLE_TO_SIGN_TOKEN = `There was an error signing the auth token. Please try again`
 export const INVALID_AUTH_TOKEN = msg =>
   `Authorization Token is invalid: ${msg}`
+
+// Bonding Curve
+export const UNABLE_TO_FETCH_TOTAL_ETH = `Unable to fetch total Ether in the bonding curve`
+export const UNABLE_TO_FETCH_TOTAL_TKN = `Unable to fetch total token in the bonding curve`
+export const UNABLE_TO_FETCH_SPREAD = `Unable to fetch spead in the of the bonding curve`

--- a/src/contracts/abstractions/BondingCurve.js
+++ b/src/contracts/abstractions/BondingCurve.js
@@ -1,0 +1,13 @@
+import AbstractContract from '../AbstractContract'
+
+class BondingCurve extends AbstractContract {
+  /* Methods delegated to implementation:
+      getTotalETH
+      getTotalTKN
+      getSpread
+      buy
+      sell
+  */
+}
+
+export default BondingCurve

--- a/src/contracts/abstractions/index.js
+++ b/src/contracts/abstractions/index.js
@@ -1,4 +1,5 @@
 import Arbitrator from './Arbitrator'
 import Arbitrable from './Arbitrable'
+import BondingCurve from './BondingCurve'
 
-export { Arbitrator, Arbitrable }
+export { Arbitrator, Arbitrable, BondingCurve }

--- a/src/contracts/implementations/PNK/MiniMePinakion.js
+++ b/src/contracts/implementations/PNK/MiniMePinakion.js
@@ -87,13 +87,13 @@ class MiniMePinakion extends ContractImplementation {
    * @param {string} account - The users account.
    * @returns {bool} If the transfer succeeded or not
    */
-  approveAndCall = async (arbitratorAddress, amount, account) => {
+  approveAndCall = async (arbitratorAddress, amount, account, extraData='0x0') => {
     await this.loadContract()
 
     return this.contractInstance.approveAndCall(
       arbitratorAddress,
       amount,
-      '0x0',
+      extraData,
       {
         from: account
       }

--- a/src/contracts/implementations/bonding-curve.js
+++ b/src/contracts/implementations/bonding-curve.js
@@ -1,0 +1,113 @@
+import { BN } from 'ethjs'
+import bondingCurveArtifact from 'kleros-interaction/build/contracts/BondingCurve'
+
+import ContractImplementation from '../ContractImplementation'
+import * as errorConstants from '../../constants/error'
+
+import MiniMePinakion from './PNK/MiniMePinakion'
+
+/**
+ * Provides interaction with a bonding curve contract on the blockchain.
+ */
+class BondingCurve extends ContractImplementation {
+  /**
+   * Create new Bonding Curve Implementation.
+   * @param {object} web3Provider - web3 instance.
+   * @param {string} contractAddress - Address of the Bonding Curve contract.
+   */
+  constructor(web3Provider, contractAddress) {
+    super(web3Provider, bondingCurveArtifact, contractAddress)
+  }
+
+  /**
+   * Fetch the total amount of ETH in the bonding curve.
+   * @returns {number} - The total amount of ETH as a BigNumber.
+   */
+  getTotalETH = async () => {
+    await this.loadContract()
+    try {
+      return this.contractInstance.totalETH()
+    } catch (err) {
+      console.error(err)
+      throw new Error(errorConstants.UNABLE_TO_FETCH_TOTAL_ETH)
+    }
+  }
+
+  /**
+   * Fetch the total amount of bonded token in the bonding curve.
+   * @returns {number} - The total amount of bonded token as a BigNumber.
+   */
+  getTotalTKN = async () => {
+    await this.loadContract()
+    try {
+      return this.contractInstance.totalTKN()
+    } catch (err) {
+      console.error(err)
+      throw new Error(errorConstants.UNABLE_TO_FETCH_TOTAL_TKN)
+    }
+  }
+
+  /**
+   * Fetch the spead of the bonding curve.
+   * @returns {number} - The spread as a BigNumber.
+   */
+  getSpread = async () => {
+    await this.loadContract()
+    try {
+      return this.contractInstance.spread()
+    } catch (err) {
+      console.error(err)
+      throw new Error(errorConstants.UNABLE_TO_FETCH_SPREAD)
+    }
+  }
+
+  /**
+   * Buy bonded token from the bonding curve.
+   * @param {string} receiver - The account the brought token is accredited to.
+   * @param {string} minTKN - The minimum amount of bonded token expected in return.
+   * @param {string} amount - The amount of ETH to spend.
+   * @param {string} account - The address of the buyer.
+   * @returns {object} - The result transaction object.
+   */
+  buy = async (receiver, minTKN, amount, account) => {
+    await this.loadContract()
+    return this.contractInstance.buy(receiver, minTKN, {
+      from: account,
+      value: amount,
+      gas: process.env.GAS || undefined
+    })
+  }
+
+  /**
+   * Sell bonded token to the bonding curve.
+   * @param {string} amountTKN - The amount of token to sell.
+   * @param {stirng} receiverAddr - The address to receive ETH.
+   * @param {string} minETH - The minimum amount of ETH expected in return.
+   * @param {string} account - The address of the seller.
+   * @returns {object} - The result transaction object.
+   */
+  sell = async (amountTKN, receiverAddr, minETH, account) => {
+    await this.loadContract()
+
+    const pinakionContractAddress = await this.contractInstance.tokenContract()
+    const pnkInstance = new MiniMePinakion(
+      this.getWeb3Provider(),
+      pinakionContractAddress
+    )
+
+    // See BondingCurve.sol in kleros-interaction for the definition of extraData.
+    const extraData =
+      '0x62637331' + // Magic number for string "bcs1"
+      (receiverAddr.startsWith('0x') ? receiverAddr.slice(2) : receiverAddr) +
+      new BN(minETH).toString(16, 64)
+
+    return pnkInstance.approveAndCall(
+      this.contractAddress,
+      amountTKN,
+      account,
+      extraData
+    )
+  }
+}
+
+export { BondingCurve }

--- a/src/contracts/implementations/index.js
+++ b/src/contracts/implementations/index.js
@@ -2,5 +2,6 @@ import * as arbitrator from './arbitrator'
 import * as arbitrable from './arbitrable'
 import * as PNK from './PNK'
 import * as RNG from './RNG'
+import * as bondingCurve from './bonding-curve'
 
-export { arbitrator, arbitrable, PNK, RNG }
+export { arbitrator, arbitrable, PNK, RNG, bondingCurve }

--- a/src/kleros.js
+++ b/src/kleros.js
@@ -33,12 +33,14 @@ class Kleros {
    *                 use when initializing KlerosPOC
    * @param {string} arbitrableContractAddress - Address of the arbitrator contract we should
    *                 use when initializing KlerosPOC
+   * @param {string} bondingCurveAddress - Address of the bonding curve contract.
    */
   constructor(
     ethereumProvider = isRequired('ethereumProvider'),
     storeUri = isRequired('storeUri'),
     arbitratorAddress,
-    arbitrableContractAddress
+    arbitrableContractAddress,
+    bondingCurveAddress
   ) {
     /**
      * We need a set of implementations that we expose to the outside api and a set we use
@@ -55,6 +57,10 @@ class Kleros {
     const _arbitrableTransaction = new contracts.implementations.arbitrable.MultipleArbitrableTransaction(
       ethereumProvider,
       arbitrableContractAddress
+    )
+    const _bondingCurve = new contracts.implementations.bondingCurve.BondingCurve(
+      ethereumProvider,
+      bondingCurveAddress
     )
     // INTERNAL
     const _klerosPOCInternal = new contracts.implementations.arbitrator.KlerosPOC(
@@ -80,6 +86,11 @@ class Kleros {
     // ARBITRABLE CONTRACTS
     this.arbitrable = new contracts.abstractions.Arbitrable(
       _arbitrableTransaction,
+      this.storeWrapper
+    )
+    // BONDING CURVE
+    this.bondingCurve = new contracts.abstractions.BondingCurve(
+      _bondingCurve,
       this.storeWrapper
     )
 


### PR DESCRIPTION
One thing I'm completely sure about is to expose `bondingCurve` through the `Kleros`  class as I do in this PR. I feel that the bonding curve is not as coherent  constituent as arbitrator and arbitrable are. Will putting them together mislead the user? 