### PR TITLE
fix: timestamps caching error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kleros-api",
+  "name": "kleros-api-2",
   "version": "0.18.7",
   "description": "A Javascript library that makes it easy to build relayers and other DApps that use the Kleros protocol.",
   "keywords": [

--- a/src/contracts/implementations/arbitrable/MultipleArbitrableTransaction.js
+++ b/src/contracts/implementations/arbitrable/MultipleArbitrableTransaction.js
@@ -315,6 +315,23 @@ class MultipleArbitrableTransaction extends Arbitrable {
   setArbitrableTransactionId = arbitrableTransactionId =>
     (this.arbitrableTransactionId = arbitrableTransactionId)
 
+    /**
+     * Fetch the parties involved in the arbitrable transaction contract.
+     * @returns {object} returns a mapping of partyA and partyB to ETH addresses.
+     */
+    getParties = async (arbitrableTransactionId) => {
+      await this.loadContract()
+
+      const arbitrableTransaction = await this.contractInstance.transactions(
+        arbitrableTransactionId
+      )
+
+      return {
+        seller: arbitrableTransaction[0],
+        buyer: arbitrableTransaction[1]
+      }
+    }
+
   /**
    * Data of the contract
    * @param {number} arbitrableTransactionId - The index of the transaction.

--- a/src/contracts/implementations/arbitrator/Kleros.js
+++ b/src/contracts/implementations/arbitrator/Kleros.js
@@ -337,6 +337,7 @@ class Kleros extends ContractImplementation {
 
       let voteCounters = []
       const status = await this.contractInstance.disputeStatus(disputeID)
+
       if (withVoteCount) {
         for (let appeal = 0; appeal <= numberOfAppeals; appeal++) {
           const voteCounts = []

--- a/src/resources/Disputes.js
+++ b/src/resources/Disputes.js
@@ -220,9 +220,8 @@ class Disputes {
    * @returns {number} timestamp of the appeal
    */
   getAppealRuledAt = async (disputeID, appeal = 0) => {
-    const cachedDispute = this.disputeCache[disputeID]
+    const cachedDispute = this.disputeCache[disputeID] || {}
     if (
-      cachedDispute &&
       cachedDispute.appealRuledAt &&
       cachedDispute.appealRuledAt[appeal]
     )
@@ -253,9 +252,8 @@ class Disputes {
    * @returns {number} timestamp of the appeal
    */
   getAppealCreatedAt = async (disputeID, account, appeal = 0) => {
-    const cachedDispute = this.disputeCache[disputeID]
+    const cachedDispute = this.disputeCache[disputeID] || {}
     if (
-      cachedDispute &&
       cachedDispute.appealCreatedAt &&
       cachedDispute.appealCreatedAt[appeal]
     )

--- a/src/utils/StoreProviderWrapper.js
+++ b/src/utils/StoreProviderWrapper.js
@@ -116,7 +116,7 @@ class StoreProviderWrapper {
       userProfile.disputes,
       o =>
         o.arbitratorAddress === arbitratorAddress && o.disputeId === disputeID
-    )[0]
+    )[0] || {}
     dispute.disputeID = dispute.disputeId
     return dispute
   }


### PR DESCRIPTION
- default timestamp cached object to `{}`
- fix error for missing dispute in store
- add getParties to Multiple Arbitrable Tx (this may not be needed since aliases is used instead anyways)